### PR TITLE
Adds option to use different units (milliseconds, seconds, minutes, hours)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   Duration _duration = const Duration(hours: 0, minutes: 0);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -58,8 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
                     initialTime: const Duration(seconds: 30),
                     baseUnit: BaseUnit.second,
                   );
-                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                      content: Text('Chose duration: $resultingDuration')));
+                  ScaffoldMessenger.of(context)
+                      .showSnackBar(SnackBar(content: Text('Chose duration: $resultingDuration')));
                 },
                 tooltip: 'Popup Duration Picker',
                 child: const Icon(Icons.add),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
-import 'package:duration_picker/duration_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:duration_picker/duration_picker.dart';
 
 void main() => runApp(const MyApp());
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:duration_picker/duration_picker.dart';
+import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
 
@@ -55,7 +55,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 onPressed: () async {
                   var resultingDuration = await showDurationPicker(
                     context: context,
-                    initialTime: const Duration(minutes: 30),
+                    initialTime: const Duration(seconds: 30),
+                    baseUnit: BaseUnit.second,
                   );
                   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                       content: Text('Chose duration: $resultingDuration')));

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,8 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
                     initialTime: const Duration(seconds: 30),
                     baseUnit: BaseUnit.second,
                   );
-                  ScaffoldMessenger.of(context)
-                      .showSnackBar(SnackBar(content: Text('Chose duration: $resultingDuration')));
+                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                      content: Text('Chose duration: $resultingDuration')));
                 },
                 tooltip: 'Popup Duration Picker',
                 child: const Icon(Icons.add),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -113,7 +113,6 @@ class _DialPainter extends CustomPainter {
     }
 
     // Draw the Text in the center of the circle which displays the duration string
-    // TODO: Handle units
     var secondaryUnits = (baseUnitMultiplier == 0) ? '' : '$baseUnitMultiplier${getSecondaryUnitString()} ';
     var baseUnits = '$baseUnitHand';
 
@@ -121,7 +120,10 @@ class _DialPainter extends CustomPainter {
         textAlign: TextAlign.center,
         text: TextSpan(
             text: '$secondaryUnits$baseUnits',
-            style: Theme.of(context).textTheme.headline2!.copyWith(fontSize: size.shortestSide * 0.15)),
+            style: Theme.of(context)
+                .textTheme
+                .headline2!
+                .copyWith(fontSize: size.shortestSide * 0.15)),
         textDirection: TextDirection.ltr)
       ..layout();
     var middleForValueText = Offset(
@@ -265,7 +267,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
   void _animateTo(double targetTheta) {
     final currentTheta = _theta.value;
     var beginTheta =
-    _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
+        _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
     beginTheta = _nearest(targetTheta, beginTheta, currentTheta - _kTwoPi);
     _thetaTween
       ..begin = beginTheta
@@ -600,10 +602,10 @@ class _DurationPickerDialog extends StatefulWidget {
   /// [initialTime] must not be null.
   const _DurationPickerDialog(
       {Key? key,
-        required this.initialTime,
-        this.baseUnit = BaseUnit.minute,
-        this.snapToMins = 1.0,
-        this.decoration})
+      required this.initialTime,
+      this.baseUnit = BaseUnit.minute,
+      this.snapToMins = 1.0,
+      this.decoration})
       : super(key: key);
 
   /// The duration initially selected when the dialog is shown.
@@ -677,46 +679,46 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
 
     final dialog = Dialog(child: OrientationBuilder(
         builder: (BuildContext context, Orientation orientation) {
-          final Widget pickerAndActions = Container(
-            decoration: boxDecoration,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Expanded(
-                    child:
-                    picker), // picker grows and shrinks with the available space
-                actions,
-              ],
-            ),
-          );
+        final Widget pickerAndActions = Container(
+          decoration: boxDecoration,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Expanded(
+                  child:
+                  picker), // picker grows and shrinks with the available space
+              actions,
+            ],
+          ),
+        );
 
-          switch (orientation) {
-            case Orientation.portrait:
-              return SizedBox(
-                  width: _kDurationPickerWidthPortrait,
-                  height: _kDurationPickerHeightPortrait,
-                  child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        Expanded(
-                          child: pickerAndActions,
-                        ),
-                      ]));
-            case Orientation.landscape:
-              return SizedBox(
-                  width: _kDurationPickerWidthLandscape,
-                  height: _kDurationPickerHeightLandscape,
-                  child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        Flexible(
-                          child: pickerAndActions,
-                        ),
-                      ]));
-          }
-        }));
+        switch (orientation) {
+          case Orientation.portrait:
+            return SizedBox(
+                width: _kDurationPickerWidthPortrait,
+                height: _kDurationPickerHeightPortrait,
+                child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Expanded(
+                        child: pickerAndActions,
+                      ),
+                    ]));
+          case Orientation.landscape:
+            return SizedBox(
+                width: _kDurationPickerWidthLandscape,
+                height: _kDurationPickerHeightLandscape,
+                child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Flexible(
+                        child: pickerAndActions,
+                      ),
+                    ]));
+        }
+      }));
 
     return Theme(
       data: theme.copyWith(
@@ -747,10 +749,10 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
 /// ```
 Future<Duration?> showDurationPicker(
     {required BuildContext context,
-      required Duration initialTime,
-      BaseUnit baseUnit = BaseUnit.minute,
-      double snapToMins = 1.0,
-      BoxDecoration? decoration}) async {
+    required Duration initialTime,
+    BaseUnit baseUnit = BaseUnit.minute,
+    double snapToMins = 1.0,
+    BoxDecoration? decoration}) async {
   return await showDialog<Duration>(
     context: context,
     builder: (BuildContext context) => _DurationPickerDialog(
@@ -773,12 +775,12 @@ class DurationPicker extends StatelessWidget {
 
   const DurationPicker(
       {Key? key,
-        this.duration = const Duration(minutes: 0),
-        required this.onChange,
-        this.baseUnit = BaseUnit.minute,
-        this.snapToMins,
-        this.width,
-        this.height})
+      this.duration = const Duration(minutes: 0),
+      required this.onChange,
+      this.baseUnit = BaseUnit.minute,
+      this.snapToMins,
+      this.width,
+      this.height})
       : super(key: key);
 
   @override

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -66,18 +66,15 @@ class _DialPainter extends CustomPainter {
 
     // Draw a translucent circle for every secondary unit
     for (var i = 0; i < baseUnitMultiplier; i = i + 1) {
-      canvas.drawCircle(centerPoint, radius,
-        Paint()..color = accentColor.withOpacity((i == 0) ? 0.3 : 0.1));
+      canvas.drawCircle(centerPoint, radius, Paint()..color = accentColor.withOpacity((i == 0) ? 0.3 : 0.1));
     }
 
     // Draw the inner background circle
-    canvas.drawCircle(centerPoint, radius * 0.88,
-        Paint()..color = Theme.of(context).canvasColor);
+    canvas.drawCircle(centerPoint, radius * 0.88, Paint()..color = Theme.of(context).canvasColor);
 
     // Get the offset point for an angle value of theta, and a distance of _radius
     Offset getOffsetForTheta(double theta, double _radius) {
-      return center +
-          Offset(_radius * math.cos(theta), -_radius * math.sin(theta));
+      return center + Offset(_radius * math.cos(theta), -_radius * math.sin(theta));
     }
 
     // Draw the handle that is used to drag and to indicate the position around the circle
@@ -121,15 +118,11 @@ class _DialPainter extends CustomPainter {
         textAlign: TextAlign.center,
         text: TextSpan(
             text: '$secondaryUnits$baseUnits',
-            style: Theme.of(context)
-                .textTheme
-                .headline2!
-                .copyWith(fontSize: size.shortestSide * 0.15)),
+            style: Theme.of(context).textTheme.headline2!.copyWith(fontSize: size.shortestSide * 0.15)),
         textDirection: TextDirection.ltr)
       ..layout();
     var middleForValueText = Offset(
-        centerPoint.dx - (textDurationValuePainter.width / 2),
-        centerPoint.dy - textDurationValuePainter.height / 2);
+        centerPoint.dx - (textDurationValuePainter.width / 2), centerPoint.dy - textDurationValuePainter.height / 2);
     textDurationValuePainter.paint(canvas, middleForValueText);
 
     var textMinPainter = TextPainter(
@@ -141,11 +134,8 @@ class _DialPainter extends CustomPainter {
       ..layout();
     textMinPainter.paint(
         canvas,
-        Offset(
-            centerPoint.dx - (textMinPainter.width / 2),
-            centerPoint.dy +
-                (textDurationValuePainter.height / 2) -
-                textMinPainter.height / 2));
+        Offset(centerPoint.dx - (textMinPainter.width / 2),
+            centerPoint.dy + (textDurationValuePainter.height / 2) - textMinPainter.height / 2));
 
     // Draw an arc around the circle for the amount of the circle that has elapsed.
     var elapsedPainter = Paint()
@@ -174,8 +164,7 @@ class _DialPainter extends CustomPainter {
       for (var label in labels) {
         final labelOffset = Offset(-label.width / 2.0, -label.height / 2.0);
 
-        label.paint(
-            canvas, getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset);
+        label.paint(canvas, getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset);
 
         labelTheta += labelThetaIncrement;
       }
@@ -203,6 +192,7 @@ class _Dial extends StatefulWidget {
 
   /// The resolution of mins of the dial, i.e. if snapToMins = 5.0, only durations of 5min intervals will be selectable.
   final double? snapToMins;
+
   @override
   _DialState createState() => _DialState();
 }
@@ -216,8 +206,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       vsync: this,
     );
     _thetaTween = Tween<double>(begin: _getThetaForDuration(widget.duration, widget.baseUnit));
-    _theta = _thetaTween.animate(
-        CurvedAnimation(parent: _thetaController, curve: Curves.fastOutSlowIn))
+    _theta = _thetaTween.animate(CurvedAnimation(parent: _thetaController, curve: Curves.fastOutSlowIn))
       ..addListener(() => setState(() {}));
     _thetaController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
@@ -267,8 +256,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   void _animateTo(double targetTheta) {
     final currentTheta = _theta.value;
-    var beginTheta =
-        _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
+    var beginTheta = _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
     beginTheta = _nearest(targetTheta, beginTheta, currentTheta - _kTwoPi);
     _thetaTween
       ..begin = beginTheta
@@ -602,11 +590,7 @@ class _DurationPickerDialog extends StatefulWidget {
   ///
   /// [initialTime] must not be null.
   const _DurationPickerDialog(
-      {Key? key,
-      required this.initialTime,
-      this.baseUnit = BaseUnit.minute,
-      this.snapToMins = 1.0,
-      this.decoration})
+      {Key? key, required this.initialTime, this.baseUnit = BaseUnit.minute, this.snapToMins = 1.0, this.decoration})
       : super(key: key);
 
   /// The duration initially selected when the dialog is shown.
@@ -655,8 +639,7 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     final theme = Theme.of(context);
-    final boxDecoration =
-        widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
+    final boxDecoration = widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
     final Widget picker = Padding(
         padding: const EdgeInsets.all(16.0),
         child: AspectRatio(
@@ -671,55 +654,49 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
     final Widget actions = ButtonBarTheme(
         data: ButtonBarTheme.of(context),
         child: ButtonBar(children: <Widget>[
-          TextButton(
-              onPressed: _handleCancel,
-              child: Text(localizations.cancelButtonLabel)),
-          TextButton(
-              onPressed: _handleOk, child: Text(localizations.okButtonLabel)),
+          TextButton(onPressed: _handleCancel, child: Text(localizations.cancelButtonLabel)),
+          TextButton(onPressed: _handleOk, child: Text(localizations.okButtonLabel)),
         ]));
 
-    final dialog = Dialog(child: OrientationBuilder(
-        builder: (BuildContext context, Orientation orientation) {
-          final Widget pickerAndActions = Container(
-            decoration: boxDecoration,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Expanded(
-                    child:
-                    picker), // picker grows and shrinks with the available space
-                actions,
-              ],
-            ),
-          );
+    final dialog = Dialog(child: OrientationBuilder(builder: (BuildContext context, Orientation orientation) {
+      final Widget pickerAndActions = Container(
+        decoration: boxDecoration,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Expanded(child: picker), // picker grows and shrinks with the available space
+            actions,
+          ],
+        ),
+      );
 
-          switch (orientation) {
-            case Orientation.portrait:
-              return SizedBox(
-                  width: _kDurationPickerWidthPortrait,
-                  height: _kDurationPickerHeightPortrait,
-                  child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        Expanded(
-                          child: pickerAndActions,
-                        ),
-                      ]));
-            case Orientation.landscape:
-              return SizedBox(
-                  width: _kDurationPickerWidthLandscape,
-                  height: _kDurationPickerHeightLandscape,
-                  child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        Flexible(
-                          child: pickerAndActions,
-                        ),
-                      ]));
-          }
-        }));
+      switch (orientation) {
+        case Orientation.portrait:
+          return SizedBox(
+              width: _kDurationPickerWidthPortrait,
+              height: _kDurationPickerHeightPortrait,
+              child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Expanded(
+                      child: pickerAndActions,
+                    ),
+                  ]));
+        case Orientation.landscape:
+          return SizedBox(
+              width: _kDurationPickerWidthLandscape,
+              height: _kDurationPickerHeightLandscape,
+              child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Flexible(
+                      child: pickerAndActions,
+                    ),
+                  ]));
+      }
+    }));
 
     return Theme(
       data: theme.copyWith(
@@ -789,19 +766,17 @@ class DurationPicker extends StatelessWidget {
     return SizedBox(
         width: width ?? _kDurationPickerWidthPortrait / 1.5,
         height: height ?? _kDurationPickerHeightPortrait / 1.5,
-        child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Expanded(
-                child: _Dial(
-                  duration: duration,
-                  onChanged: onChange,
-                  baseUnit: baseUnit,
-                  snapToMins: snapToMins,
-                ),
-              ),
-            ]));
+        child:
+            Column(mainAxisSize: MainAxisSize.min, crossAxisAlignment: CrossAxisAlignment.stretch, children: <Widget>[
+          Expanded(
+            child: _Dial(
+              duration: duration,
+              onChanged: onChange,
+              baseUnit: baseUnit,
+              snapToMins: snapToMins,
+            ),
+          ),
+        ]));
   }
 }
 

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -66,15 +66,18 @@ class _DialPainter extends CustomPainter {
 
     // Draw a translucent circle for every secondary unit
     for (var i = 0; i < baseUnitMultiplier; i = i + 1) {
-      canvas.drawCircle(centerPoint, radius, Paint()..color = accentColor.withOpacity((i == 0) ? 0.3 : 0.1));
+      canvas.drawCircle(centerPoint, radius,
+          Paint()..color = accentColor.withOpacity((i == 0) ? 0.3 : 0.1));
     }
 
     // Draw the inner background circle
-    canvas.drawCircle(centerPoint, radius * 0.88, Paint()..color = Theme.of(context).canvasColor);
+    canvas.drawCircle(centerPoint, radius * 0.88,
+        Paint()..color = Theme.of(context).canvasColor);
 
     // Get the offset point for an angle value of theta, and a distance of _radius
     Offset getOffsetForTheta(double theta, double _radius) {
-      return center + Offset(_radius * math.cos(theta), -_radius * math.sin(theta));
+      return center +
+          Offset(_radius * math.cos(theta), -_radius * math.sin(theta));
     }
 
     // Draw the handle that is used to drag and to indicate the position around the circle
@@ -111,18 +114,24 @@ class _DialPainter extends CustomPainter {
     }
 
     // Draw the Text in the center of the circle which displays the duration string
-    var secondaryUnits = (baseUnitMultiplier == 0) ? '' : '$baseUnitMultiplier${getSecondaryUnitString()} ';
+    var secondaryUnits = (baseUnitMultiplier == 0)
+        ? ''
+        : '$baseUnitMultiplier${getSecondaryUnitString()} ';
     var baseUnits = '$baseUnitHand';
 
     var textDurationValuePainter = TextPainter(
         textAlign: TextAlign.center,
         text: TextSpan(
             text: '$secondaryUnits$baseUnits',
-            style: Theme.of(context).textTheme.headline2!.copyWith(fontSize: size.shortestSide * 0.15)),
+            style: Theme.of(context)
+                .textTheme
+                .headline2!
+                .copyWith(fontSize: size.shortestSide * 0.15)),
         textDirection: TextDirection.ltr)
       ..layout();
     var middleForValueText = Offset(
-        centerPoint.dx - (textDurationValuePainter.width / 2), centerPoint.dy - textDurationValuePainter.height / 2);
+        centerPoint.dx - (textDurationValuePainter.width / 2),
+        centerPoint.dy - textDurationValuePainter.height / 2);
     textDurationValuePainter.paint(canvas, middleForValueText);
 
     var textMinPainter = TextPainter(
@@ -134,8 +143,11 @@ class _DialPainter extends CustomPainter {
       ..layout();
     textMinPainter.paint(
         canvas,
-        Offset(centerPoint.dx - (textMinPainter.width / 2),
-            centerPoint.dy + (textDurationValuePainter.height / 2) - textMinPainter.height / 2));
+        Offset(
+            centerPoint.dx - (textMinPainter.width / 2),
+            centerPoint.dy +
+                (textDurationValuePainter.height / 2) -
+                textMinPainter.height / 2));
 
     // Draw an arc around the circle for the amount of the circle that has elapsed.
     var elapsedPainter = Paint()
@@ -164,7 +176,8 @@ class _DialPainter extends CustomPainter {
       for (var label in labels) {
         final labelOffset = Offset(-label.width / 2.0, -label.height / 2.0);
 
-        label.paint(canvas, getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset);
+        label.paint(
+            canvas, getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset);
 
         labelTheta += labelThetaIncrement;
       }
@@ -184,7 +197,10 @@ class _DialPainter extends CustomPainter {
 
 class _Dial extends StatefulWidget {
   const _Dial(
-      {required this.duration, required this.onChanged, this.baseUnit = BaseUnit.minute, this.snapToMins = 1.0});
+      {required this.duration,
+      required this.onChanged,
+      this.baseUnit = BaseUnit.minute,
+      this.snapToMins = 1.0});
 
   final Duration duration;
   final ValueChanged<Duration> onChanged;
@@ -205,8 +221,10 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       duration: _kDialAnimateDuration,
       vsync: this,
     );
-    _thetaTween = Tween<double>(begin: _getThetaForDuration(widget.duration, widget.baseUnit));
-    _theta = _thetaTween.animate(CurvedAnimation(parent: _thetaController, curve: Curves.fastOutSlowIn))
+    _thetaTween = Tween<double>(
+        begin: _getThetaForDuration(widget.duration, widget.baseUnit));
+    _theta = _thetaTween.animate(
+        CurvedAnimation(parent: _thetaController, curve: Curves.fastOutSlowIn))
       ..addListener(() => setState(() {}));
     _thetaController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
@@ -256,7 +274,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   void _animateTo(double targetTheta) {
     final currentTheta = _theta.value;
-    var beginTheta = _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
+    var beginTheta =
+        _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
     beginTheta = _nearest(targetTheta, beginTheta, currentTheta - _kTwoPi);
     _thetaTween
       ..begin = beginTheta
@@ -315,7 +334,11 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     int baseUnits = _getDurationInBaseUnits(duration, baseUnit);
     int baseToSecondaryFactor = _getBaseUnitToSecondaryUnitFactor(baseUnit);
 
-    return (_kPiByTwo - (baseUnits % baseToSecondaryFactor) / baseToSecondaryFactor.toDouble() * _kTwoPi) % _kTwoPi;
+    return (_kPiByTwo -
+            (baseUnits % baseToSecondaryFactor) /
+                baseToSecondaryFactor.toDouble() *
+                _kTwoPi) %
+        _kTwoPi;
   }
 
   double _turningAngleFactor() {
@@ -422,13 +445,16 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
             milliseconds: (baseUnitValue % unitFactor.toDouble()).toInt());
       case BaseUnit.second:
         return Duration(
-            minutes: (baseUnitValue ~/ unitFactor).toInt(), seconds: (baseUnitValue % unitFactor.toDouble()).toInt());
+            minutes: (baseUnitValue ~/ unitFactor).toInt(),
+            seconds: (baseUnitValue % unitFactor.toDouble()).toInt());
       case BaseUnit.minute:
         return Duration(
-            hours: (baseUnitValue ~/ unitFactor).toInt(), minutes: (baseUnitValue % unitFactor.toDouble()).toInt());
+            hours: (baseUnitValue ~/ unitFactor).toInt(),
+            minutes: (baseUnitValue % unitFactor.toDouble()).toInt());
       case BaseUnit.hour:
         return Duration(
-            days: (baseUnitValue ~/ unitFactor).toInt(), hours: (baseUnitValue % unitFactor.toDouble()).toInt());
+            days: (baseUnitValue ~/ unitFactor).toInt(),
+            hours: (baseUnitValue % unitFactor.toDouble()).toInt());
     }
   }
 
@@ -450,7 +476,9 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     var dialAngle = _kPiByTwo - angle;
 
     // Turn dial angle into minutes, may go beyond 60 minutes (multiple turns)
-    return dialAngle / _kTwoPi * _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
+    return dialAngle /
+        _kTwoPi *
+        _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
   }
 
   void _updateTurningAngle(double oldTheta, double newTheta) {
@@ -488,7 +516,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     _updateThetaForPan();
     _notifyOnChangedIfNeeded();
 
-    _animateTo(_getThetaForDuration(_getTimeForTheta(_theta.value), widget.baseUnit));
+    _animateTo(
+        _getThetaForDuration(_getTimeForTheta(_theta.value), widget.baseUnit));
     _dragging = false;
     _position = null;
     _center = null;
@@ -504,25 +533,29 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
         int interval = 100;
         int factor = Duration.millisecondsPerSecond;
         int length = factor ~/ interval;
-        baseUnitMarkerValues = List.generate(length, (index) => Duration(milliseconds: index * interval));
+        baseUnitMarkerValues = List.generate(
+            length, (index) => Duration(milliseconds: index * interval));
         break;
       case BaseUnit.second:
         int interval = 5;
         int factor = Duration.secondsPerMinute;
         int length = factor ~/ interval;
-        baseUnitMarkerValues = List.generate(length, (index) => Duration(seconds: index * interval));
+        baseUnitMarkerValues = List.generate(
+            length, (index) => Duration(seconds: index * interval));
         break;
       case BaseUnit.minute:
         int interval = 5;
         int factor = Duration.minutesPerHour;
         int length = factor ~/ interval;
-        baseUnitMarkerValues = List.generate(length, (index) => Duration(minutes: index * interval));
+        baseUnitMarkerValues = List.generate(
+            length, (index) => Duration(minutes: index * interval));
         break;
       case BaseUnit.hour:
         int interval = 3;
         int factor = Duration.hoursPerDay;
         int length = factor ~/ interval;
-        baseUnitMarkerValues = List.generate(length, (index) => Duration(hours: index * interval));
+        baseUnitMarkerValues =
+            List.generate(length, (index) => Duration(hours: index * interval));
         break;
     }
 
@@ -590,7 +623,11 @@ class _DurationPickerDialog extends StatefulWidget {
   ///
   /// [initialTime] must not be null.
   const _DurationPickerDialog(
-      {Key? key, required this.initialTime, this.baseUnit = BaseUnit.minute, this.snapToMins = 1.0, this.decoration})
+      {Key? key,
+      required this.initialTime,
+      this.baseUnit = BaseUnit.minute,
+      this.snapToMins = 1.0,
+      this.decoration})
       : super(key: key);
 
   /// The duration initially selected when the dialog is shown.
@@ -639,7 +676,8 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     final theme = Theme.of(context);
-    final boxDecoration = widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
+    final boxDecoration =
+        widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
     final Widget picker = Padding(
         padding: const EdgeInsets.all(16.0),
         child: AspectRatio(
@@ -654,17 +692,23 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
     final Widget actions = ButtonBarTheme(
         data: ButtonBarTheme.of(context),
         child: ButtonBar(children: <Widget>[
-          TextButton(onPressed: _handleCancel, child: Text(localizations.cancelButtonLabel)),
-          TextButton(onPressed: _handleOk, child: Text(localizations.okButtonLabel)),
+          TextButton(
+              onPressed: _handleCancel,
+              child: Text(localizations.cancelButtonLabel)),
+          TextButton(
+              onPressed: _handleOk, child: Text(localizations.okButtonLabel)),
         ]));
 
-    final dialog = Dialog(child: OrientationBuilder(builder: (BuildContext context, Orientation orientation) {
+    final dialog = Dialog(child: OrientationBuilder(
+        builder: (BuildContext context, Orientation orientation) {
       final Widget pickerAndActions = Container(
         decoration: boxDecoration,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Expanded(child: picker), // picker grows and shrinks with the available space
+            Expanded(
+                child:
+                    picker), // picker grows and shrinks with the available space
             actions,
           ],
         ),
@@ -766,17 +810,19 @@ class DurationPicker extends StatelessWidget {
     return SizedBox(
         width: width ?? _kDurationPickerWidthPortrait / 1.5,
         height: height ?? _kDurationPickerHeightPortrait / 1.5,
-        child:
-            Column(mainAxisSize: MainAxisSize.min, crossAxisAlignment: CrossAxisAlignment.stretch, children: <Widget>[
-          Expanded(
-            child: _Dial(
-              duration: duration,
-              onChanged: onChange,
-              baseUnit: baseUnit,
-              snapToMins: snapToMins,
-            ),
-          ),
-        ]));
+        child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(
+                child: _Dial(
+                  duration: duration,
+                  onChanged: onChange,
+                  baseUnit: baseUnit,
+                  snapToMins: snapToMins,
+                ),
+              ),
+            ]));
   }
 }
 

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -70,11 +70,13 @@ class _DialPainter extends CustomPainter {
     }
 
     // Draw the inner background circle
-    canvas.drawCircle(centerPoint, radius * 0.88, Paint()..color = Theme.of(context).canvasColor);
+    canvas.drawCircle(centerPoint, radius * 0.88,
+        Paint()..color = Theme.of(context).canvasColor);
 
     // Get the offset point for an angle value of theta, and a distance of _radius
     Offset getOffsetForTheta(double theta, double _radius) {
-      return center + Offset(_radius * math.cos(theta), -_radius * math.sin(theta));
+      return center +
+          Offset(_radius * math.cos(theta), -_radius * math.sin(theta));
     }
 
     // Draw the handle that is used to drag and to indicate the position around the circle
@@ -123,7 +125,8 @@ class _DialPainter extends CustomPainter {
         textDirection: TextDirection.ltr)
       ..layout();
     var middleForValueText = Offset(
-        centerPoint.dx - (textDurationValuePainter.width / 2), centerPoint.dy - textDurationValuePainter.height / 2);
+        centerPoint.dx - (textDurationValuePainter.width / 2),
+        centerPoint.dy - textDurationValuePainter.height / 2);
     textDurationValuePainter.paint(canvas, middleForValueText);
 
     var textMinPainter = TextPainter(
@@ -135,8 +138,11 @@ class _DialPainter extends CustomPainter {
       ..layout();
     textMinPainter.paint(
         canvas,
-        Offset(centerPoint.dx - (textMinPainter.width / 2),
-            centerPoint.dy + (textDurationValuePainter.height / 2) - textMinPainter.height / 2));
+        Offset(
+            centerPoint.dx - (textMinPainter.width / 2),
+            centerPoint.dy +
+                (textDurationValuePainter.height / 2) -
+                textMinPainter.height / 2));
 
     // Draw an arc around the circle for the amount of the circle that has elapsed.
     var elapsedPainter = Paint()
@@ -165,7 +171,8 @@ class _DialPainter extends CustomPainter {
       for (var label in labels) {
         final labelOffset = Offset(-label.width / 2.0, -label.height / 2.0);
 
-        label.paint(canvas, getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset);
+        label.paint(
+            canvas, getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset);
 
         labelTheta += labelThetaIncrement;
       }
@@ -206,7 +213,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       vsync: this,
     );
     _thetaTween = Tween<double>(begin: _getThetaForDuration(widget.duration, widget.baseUnit));
-    _theta = _thetaTween.animate(CurvedAnimation(parent: _thetaController, curve: Curves.fastOutSlowIn))
+    _theta = _thetaTween.animate(
+        CurvedAnimation(parent: _thetaController, curve: Curves.fastOutSlowIn))
       ..addListener(() => setState(() {}));
     _thetaController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
@@ -256,7 +264,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   void _animateTo(double targetTheta) {
     final currentTheta = _theta.value;
-    var beginTheta = _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
+    var beginTheta =
+    _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
     beginTheta = _nearest(targetTheta, beginTheta, currentTheta - _kTwoPi);
     _thetaTween
       ..begin = beginTheta
@@ -590,7 +599,11 @@ class _DurationPickerDialog extends StatefulWidget {
   ///
   /// [initialTime] must not be null.
   const _DurationPickerDialog(
-      {Key? key, required this.initialTime, this.baseUnit = BaseUnit.minute, this.snapToMins = 1.0, this.decoration})
+      {Key? key,
+        required this.initialTime,
+        this.baseUnit = BaseUnit.minute,
+        this.snapToMins = 1.0,
+        this.decoration})
       : super(key: key);
 
   /// The duration initially selected when the dialog is shown.
@@ -639,7 +652,8 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     final theme = Theme.of(context);
-    final boxDecoration = widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
+    final boxDecoration =
+        widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
     final Widget picker = Padding(
         padding: const EdgeInsets.all(16.0),
         child: AspectRatio(
@@ -654,49 +668,55 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
     final Widget actions = ButtonBarTheme(
         data: ButtonBarTheme.of(context),
         child: ButtonBar(children: <Widget>[
-          TextButton(onPressed: _handleCancel, child: Text(localizations.cancelButtonLabel)),
-          TextButton(onPressed: _handleOk, child: Text(localizations.okButtonLabel)),
+          TextButton(
+              onPressed: _handleCancel,
+              child: Text(localizations.cancelButtonLabel)),
+          TextButton(
+              onPressed: _handleOk, child: Text(localizations.okButtonLabel)),
         ]));
 
-    final dialog = Dialog(child: OrientationBuilder(builder: (BuildContext context, Orientation orientation) {
-      final Widget pickerAndActions = Container(
-        decoration: boxDecoration,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Expanded(child: picker), // picker grows and shrinks with the available space
-            actions,
-          ],
-        ),
-      );
+    final dialog = Dialog(child: OrientationBuilder(
+        builder: (BuildContext context, Orientation orientation) {
+          final Widget pickerAndActions = Container(
+            decoration: boxDecoration,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Expanded(
+                    child:
+                    picker), // picker grows and shrinks with the available space
+                actions,
+              ],
+            ),
+          );
 
-      switch (orientation) {
-        case Orientation.portrait:
-          return SizedBox(
-              width: _kDurationPickerWidthPortrait,
-              height: _kDurationPickerHeightPortrait,
-              child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Expanded(
-                      child: pickerAndActions,
-                    ),
-                  ]));
-        case Orientation.landscape:
-          return SizedBox(
-              width: _kDurationPickerWidthLandscape,
-              height: _kDurationPickerHeightLandscape,
-              child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Flexible(
-                      child: pickerAndActions,
-                    ),
-                  ]));
-      }
-    }));
+          switch (orientation) {
+            case Orientation.portrait:
+              return SizedBox(
+                  width: _kDurationPickerWidthPortrait,
+                  height: _kDurationPickerHeightPortrait,
+                  child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        Expanded(
+                          child: pickerAndActions,
+                        ),
+                      ]));
+            case Orientation.landscape:
+              return SizedBox(
+                  width: _kDurationPickerWidthLandscape,
+                  height: _kDurationPickerHeightLandscape,
+                  child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        Flexible(
+                          child: pickerAndActions,
+                        ),
+                      ]));
+          }
+        }));
 
     return Theme(
       data: theme.copyWith(
@@ -727,10 +747,10 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
 /// ```
 Future<Duration?> showDurationPicker(
     {required BuildContext context,
-    required Duration initialTime,
-    BaseUnit baseUnit = BaseUnit.minute,
-    double snapToMins = 1.0,
-    BoxDecoration? decoration}) async {
+      required Duration initialTime,
+      BaseUnit baseUnit = BaseUnit.minute,
+      double snapToMins = 1.0,
+      BoxDecoration? decoration}) async {
   return await showDialog<Duration>(
     context: context,
     builder: (BuildContext context) => _DurationPickerDialog(
@@ -753,12 +773,12 @@ class DurationPicker extends StatelessWidget {
 
   const DurationPicker(
       {Key? key,
-      this.duration = const Duration(minutes: 0),
-      required this.onChange,
-      this.baseUnit = BaseUnit.minute,
-      this.snapToMins,
-      this.width,
-      this.height})
+        this.duration = const Duration(minutes: 0),
+        required this.onChange,
+        this.baseUnit = BaseUnit.minute,
+        this.snapToMins,
+        this.width,
+        this.height})
       : super(key: key);
 
   @override
@@ -766,17 +786,19 @@ class DurationPicker extends StatelessWidget {
     return SizedBox(
         width: width ?? _kDurationPickerWidthPortrait / 1.5,
         height: height ?? _kDurationPickerHeightPortrait / 1.5,
-        child:
-            Column(mainAxisSize: MainAxisSize.min, crossAxisAlignment: CrossAxisAlignment.stretch, children: <Widget>[
-          Expanded(
-            child: _Dial(
-              duration: duration,
-              onChanged: onChange,
-              baseUnit: baseUnit,
-              snapToMins: snapToMins,
-            ),
-          ),
-        ]));
+        child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(
+                child: _Dial(
+                  duration: duration,
+                  onChanged: onChange,
+                  baseUnit: baseUnit,
+                  snapToMins: snapToMins,
+                ),
+              ),
+            ]));
   }
 }
 

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -66,7 +66,8 @@ class _DialPainter extends CustomPainter {
 
     // Draw a translucent circle for every secondary unit
     for (var i = 0; i < baseUnitMultiplier; i = i + 1) {
-      canvas.drawCircle(centerPoint, radius, Paint()..color = accentColor.withOpacity((i == 0) ? 0.3 : 0.1));
+      canvas.drawCircle(centerPoint, radius,
+        Paint()..color = accentColor.withOpacity((i == 0) ? 0.3 : 0.1));
     }
 
     // Draw the inner background circle
@@ -679,46 +680,46 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
 
     final dialog = Dialog(child: OrientationBuilder(
         builder: (BuildContext context, Orientation orientation) {
-        final Widget pickerAndActions = Container(
-          decoration: boxDecoration,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Expanded(
-                  child:
-                  picker), // picker grows and shrinks with the available space
-              actions,
-            ],
-          ),
-        );
+          final Widget pickerAndActions = Container(
+            decoration: boxDecoration,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Expanded(
+                    child:
+                    picker), // picker grows and shrinks with the available space
+                actions,
+              ],
+            ),
+          );
 
-        switch (orientation) {
-          case Orientation.portrait:
-            return SizedBox(
-                width: _kDurationPickerWidthPortrait,
-                height: _kDurationPickerHeightPortrait,
-                child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Expanded(
-                        child: pickerAndActions,
-                      ),
-                    ]));
-          case Orientation.landscape:
-            return SizedBox(
-                width: _kDurationPickerWidthLandscape,
-                height: _kDurationPickerHeightLandscape,
-                child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Flexible(
-                        child: pickerAndActions,
-                      ),
-                    ]));
-        }
-      }));
+          switch (orientation) {
+            case Orientation.portrait:
+              return SizedBox(
+                  width: _kDurationPickerWidthPortrait,
+                  height: _kDurationPickerHeightPortrait,
+                  child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        Expanded(
+                          child: pickerAndActions,
+                        ),
+                      ]));
+            case Orientation.landscape:
+              return SizedBox(
+                  width: _kDurationPickerWidthLandscape,
+                  height: _kDurationPickerHeightLandscape,
+                  child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        Flexible(
+                          child: pickerAndActions,
+                        ),
+                      ]));
+          }
+        }));
 
     return Theme(
       data: theme.copyWith(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Hello,

I really like this package, but for my purposes I need to use smaller duration increments, generally under a minute.

This PR removes the limitation of only being able to choose the duration in minutes, and adds in an option to base the duration off of different units. I've included options for milliseconds, seconds, minutes, and hours.

In terms of user functionality, this PR changes nothing for existing users and requires no changes to use. There is a single new optional parameter `baseUnit` which has a default value of `BaseUnit.minute` to ensure that all existing users will remain with their configuration unchanged.

Under the hood, there are a few changes:
- Occurences of `minute` are changed to `baseUnit`, since it could be ms, sec, min, etc.
- Occurrences of `hour` are changed to `secondaryUnit`. This is the unit just up the hierarchy from the `baseUnit`, ie for if the base is seconds, the secondary is minutes
- Use separate methods for determining the durations, conversions, strings etc

Let me know what you think, and whether I should make any changes. Thanks for the work you put into this, it's a great package.