### PR TITLE
Add a localization option

### DIFF
--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -3,6 +3,7 @@ library duration_picker;
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:duration_picker/localization/localization.dart';
 import 'package:flutter/material.dart';
 
 const Duration _kDialAnimateDuration = Duration(milliseconds: 200);
@@ -91,29 +92,33 @@ class DialPainter extends CustomPainter {
 
     // Get the appropriate base unit string
     String getBaseUnitString() {
+      final localization = DurationPickerLocalizations.of(context);
+
       switch (baseUnit) {
         case BaseUnit.millisecond:
-          return 'ms.';
+          return localization.baseUnitMillisecond;
         case BaseUnit.second:
-          return 'sec.';
+          return localization.baseUnitSecond;
         case BaseUnit.minute:
-          return 'min.';
+          return localization.baseUnitMinute;
         case BaseUnit.hour:
-          return 'hr.';
+          return localization.baseUnitHour;
       }
     }
 
     // Get the appropriate secondary unit string
     String getSecondaryUnitString() {
+      final localization = DurationPickerLocalizations.of(context);
+
       switch (baseUnit) {
         case BaseUnit.millisecond:
-          return 's ';
+          return localization.secondaryUnitMillisecond;
         case BaseUnit.second:
-          return 'm ';
+          return localization.secondaryUnitSecond;
         case BaseUnit.minute:
-          return 'h ';
+          return localization.secondaryUnitMinute;
         case BaseUnit.hour:
-          return 'd ';
+          return localization.secondaryUnitHour;
       }
     }
 

--- a/lib/localization/en.dart
+++ b/lib/localization/en.dart
@@ -1,0 +1,27 @@
+import 'package:duration_picker/localization/localization.dart';
+
+class DurationPickerLocalizationsEn extends DurationPickerLocalizations {
+  @override
+  String get baseUnitHour => 'hr.';
+
+  @override
+  String get baseUnitMillisecond => 'ms.';
+
+  @override
+  String get baseUnitMinute => 'min.';
+
+  @override
+  String get baseUnitSecond => 'sec.';
+
+  @override
+  String get secondaryUnitHour => 'd ';
+
+  @override
+  String get secondaryUnitMillisecond => 's ';
+
+  @override
+  String get secondaryUnitMinute => 'h ';
+
+  @override
+  String get secondaryUnitSecond => 'm ';
+}

--- a/lib/localization/ko.dart
+++ b/lib/localization/ko.dart
@@ -1,0 +1,27 @@
+import 'package:duration_picker/localization/localization.dart';
+
+class DurationPickerLocalizationsKo extends DurationPickerLocalizations {
+  @override
+  String get baseUnitHour => '시간';
+
+  @override
+  String get baseUnitMillisecond => '밀리초';
+
+  @override
+  String get baseUnitMinute => '분';
+
+  @override
+  String get baseUnitSecond => '초';
+
+  @override
+  String get secondaryUnitHour => '일 ';
+
+  @override
+  String get secondaryUnitMillisecond => '초 ';
+
+  @override
+  String get secondaryUnitMinute => '시간 ';
+
+  @override
+  String get secondaryUnitSecond => '분 ';
+}

--- a/lib/localization/localization.dart
+++ b/lib/localization/localization.dart
@@ -1,0 +1,56 @@
+import 'package:duration_picker/localization/en.dart';
+import 'package:duration_picker/localization/ko.dart';
+import 'package:flutter/material.dart';
+
+abstract class DurationPickerLocalizations {
+  String get baseUnitMillisecond;
+
+  String get baseUnitSecond;
+
+  String get baseUnitMinute;
+
+  String get baseUnitHour;
+
+  String get secondaryUnitMillisecond;
+
+  String get secondaryUnitSecond;
+
+  String get secondaryUnitMinute;
+
+  String get secondaryUnitHour;
+
+  static DurationPickerLocalizations of(BuildContext context) {
+    return Localizations.of<DurationPickerLocalizations>(
+          context,
+          DurationPickerLocalizations,
+        ) ??
+        DurationPickerLocalizationsEn();
+  }
+
+  static const LocalizationsDelegate<DurationPickerLocalizations> delegate =
+      _DurationPickerLocalizationDelegate();
+}
+
+class _DurationPickerLocalizationDelegate
+    extends LocalizationsDelegate<DurationPickerLocalizations> {
+  const _DurationPickerLocalizationDelegate();
+
+  static const supportedLocales = ['en', 'ko'];
+
+  @override
+  bool isSupported(Locale locale) =>
+      supportedLocales.contains(locale.languageCode);
+
+  @override
+  Future<DurationPickerLocalizations> load(Locale locale) async {
+    switch (locale.languageCode) {
+      case 'ko':
+        return DurationPickerLocalizationsKo();
+      default:
+        return DurationPickerLocalizationsEn();
+    }
+  }
+
+  @override
+  bool shouldReload(_DurationPickerLocalizationDelegate old) => false;
+}


### PR DESCRIPTION
I made this library support other languages.

My app uses this library, and I want to make people who are not familliar with English can use my app easily. Like this:

![Simulator Screenshot - iPhone 14 - 2023-07-15 at 14 06 25](https://github.com/juliansteenbakker/duration_picker/assets/101033584/7934ee9c-df4f-4dbb-817f-b04c37279ef6)

(Secondary unit text seems too large in this case though)

No change needed for developers to support English. But in order to support other languages, developers need to configure localization settings like the settings for the time picker. Example:

```dart
class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Duration Picker Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      localizationsDelegates: [
        DurationPickerLocalizations.delegate,
        GlobalMaterialLocalizations.delegate,
        GlobalWidgetsLocalizations.delegate,
        GlobalCupertinoLocalizations.delegate,
      ],
      supportedLocales: [Locale('en'), Locale('ko')],
      home: const MyHomePage(title: 'Duration Picker Demo'),
    );
  }
}
```

This code make `DurationPicker` support Korean. As I've added korean localization strings interally.

## How to add more languages

1. Add a localizations class in `localizataions` dir.

```dart
class DurationPickerLocalizationsKo extends DurationPickerLocalizations {
  @override
  String get baseUnitHour => '시간';

  @override
  String get baseUnitMillisecond => '밀리초';

  ...
}
```

The class should extend `DurationPickerLocalizations`. This makes it easy to write everything you should write.

2. Add the language code to the `supportedLocales` array in `_DurationPickerLocalizationDelegate`.

```dart
class _DurationPickerLocalizationDelegate
    extends LocalizationsDelegate<DurationPickerLocalizations> {
  const _DurationPickerLocalizationDelegate();

  static const supportedLocales = ['en', 'ko'];

  ...

}
```

3. Return a `DurationPickerLocalizations` implementation as locale at `load` method in `_DurationPickerLocalizationDelegate`.

```dart
@override
  Future<DurationPickerLocalizations> load(Locale locale) async {
    switch (locale.languageCode) {
      case 'ko':
        return DurationPickerLocalizationsKo();
      default:
        return DurationPickerLocalizationsEn();
    }
  }
```

4. Done.