### PR TITLE
Decreased the size of the outerring so that the handle is within gesture zone

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,9 +41,9 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             //PR added container  to show extent of gesture detector
-            Container(
-              color: Colors.blueGrey,
-              child: Expanded(
+            Expanded(
+              child: Container(
+                color: Colors.blueGrey,
                 child: DurationPicker(
                   duration: _duration,
                   baseUnit: BaseUnit.second,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,19 +40,23 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Expanded(
-              child: DurationPicker(
-                duration: _duration,
-                baseUnit: BaseUnit.second,
-                onChange: (val) {
-                  setState(() => _duration = val);
-                },
-                // upperBound: const Duration(
-                //   seconds: 120,
-                // ),
-                // lowerBound: const Duration(
-                //   seconds: 5,
-                // ),
+            //PR added container  to show extent of gesture detector
+            Container(
+              color: Colors.blueGrey,
+              child: Expanded(
+                child: DurationPicker(
+                  duration: _duration,
+                  baseUnit: BaseUnit.second,
+                  onChange: (val) {
+                    setState(() => _duration = val);
+                  },
+                  // upperBound: const Duration(
+                  //   seconds: 120,
+                  // ),
+                  // lowerBound: const Duration(
+                  //   seconds: 5,
+                  // ),
+                ),
               ),
             ),
           ],

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -126,15 +126,16 @@ class DialPainter extends CustomPainter {
         : '$baseUnitMultiplier${getSecondaryUnitString()} ';
     final baseUnits = '$baseUnitHand';
 
+    print ('$secondaryUnits$baseUnits');
     final textDurationValuePainter = TextPainter(
       textAlign: TextAlign.center,
       text: TextSpan(
-        text: '$secondaryUnits$baseUnits',
+        text: '$secondaryUnits$baseUnits'+getBaseUnitString(),
         style: Theme.of(context)
             .textTheme
             .bodyMedium!
             //PR shrink font as circle is now smaller
-            .copyWith(fontSize: size.shortestSide * 0.08),
+            .copyWith(fontSize: size.shortestSide * 0.07),
 
       ),
       textDirection: TextDirection.ltr,
@@ -145,24 +146,24 @@ class DialPainter extends CustomPainter {
     );
     textDurationValuePainter.paint(canvas, middleForValueText);
 
-    final textMinPainter = TextPainter(
-      textAlign: TextAlign.center,
-      text: TextSpan(
-        text: getBaseUnitString(), //th: ${theta}',
-        //PR shrink font as its resized elsewhere
-        style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: size.shortestSide * 0.06),
-      ),
-      textDirection: TextDirection.ltr,
-    )..layout();
-    textMinPainter.paint(
-      canvas,
-      Offset(
-        centerPoint.dx - (textMinPainter.width / 2),
-        centerPoint.dy +
-            (textDurationValuePainter.height / 2) -
-            textMinPainter.height / 2,
-      ),
-    );
+    // final textMinPainter = TextPainter(
+    //   textAlign: TextAlign.center,
+    //   text: TextSpan(
+    //     text: getBaseUnitString(), //th: ${theta}',
+    //     //PR shrink font as its resized elsewhere
+    //     style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: size.shortestSide * 0.06),
+    //   ),
+    //   textDirection: TextDirection.ltr,
+    // )..layout();
+    // textMinPainter.paint(
+    //   canvas,
+    //   Offset(
+    //     centerPoint.dx - (textMinPainter.width / 2),
+    //     centerPoint.dy +
+    //         (textDurationValuePainter.height / 2) -
+    //         textMinPainter.height / 2,
+    //   ),
+    // );
 
     // Draw an arc around the circle for the amount of the circle that has elapsed.
     final elapsedPainter = Paint()
@@ -193,7 +194,7 @@ class DialPainter extends CustomPainter {
 
         label.paint(
           canvas,
-          getOffsetForTheta(labelTheta, radius - 40.0) + labelOffset,
+          getOffsetForTheta(labelTheta, radius *.7) + labelOffset,
         );
 
         labelTheta += labelThetaIncrement;

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -132,9 +132,9 @@ class DialPainter extends CustomPainter {
         text: '$secondaryUnits$baseUnits',
         style: Theme.of(context)
             .textTheme
-            .displayMedium!
+            .bodyMedium!
             //PR shrink font as circle is now smaller
-            .copyWith(fontSize: size.shortestSide * 0.10),
+            .copyWith(fontSize: size.shortestSide * 0.08),
 
       ),
       textDirection: TextDirection.ltr,
@@ -150,7 +150,7 @@ class DialPainter extends CustomPainter {
       text: TextSpan(
         text: getBaseUnitString(), //th: ${theta}',
         //PR shrink font as its resized elsewhere
-        style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: size.shortestSide * 0.10),
+        style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: size.shortestSide * 0.06),
       ),
       textDirection: TextDirection.ltr,
     )..layout();

--- a/lib/localization/en.dart
+++ b/lib/localization/en.dart
@@ -2,26 +2,26 @@ import 'package:duration_picker/localization/localization.dart';
 
 class DurationPickerLocalizationsEn extends DurationPickerLocalizations {
   @override
-  String get baseUnitHour => 'hr.';
+  String get baseUnitHour => 'h';
 
   @override
-  String get baseUnitMillisecond => 'ms.';
+  String get baseUnitMillisecond => 'ms';
 
   @override
-  String get baseUnitMinute => 'min.';
+  String get baseUnitMinute => 'm';
 
   @override
-  String get baseUnitSecond => 'sec.';
+  String get baseUnitSecond => 's';
 
   @override
-  String get secondaryUnitHour => 'd ';
+  String get secondaryUnitHour => 'd';
 
   @override
-  String get secondaryUnitMillisecond => 's ';
+  String get secondaryUnitMillisecond => 'ms';
 
   @override
-  String get secondaryUnitMinute => 'h ';
+  String get secondaryUnitMinute => 'h';
 
   @override
-  String get secondaryUnitSecond => 'm ';
+  String get secondaryUnitSecond => 'm';
 }


### PR DESCRIPTION
 when trying to drag the handle,  the gesture detective was not picking up when the handle was around the fifteen minutes mark  and you click to the right of the center of circle.

 this because the circle is being painted outside of the painter area,  which is the widget that is getting the  gestures and therefore they are lost when it is outside of it.  there maybe some other approaches to deal with this,  was unable to solve it by having the gesture detector  having padding before the  custom paint.

 the side effect from making the  circle smaller the font sizes  were no longer appropriate,  however these scale funny anyway so think some work is needed here.





Resized the font to suit the slightly smaller display

Resized landscape height as was too small

made fonts scalable

tweaked english localistion to fit duration on single line