### PR TITLE
Support for de locale

### DIFF
--- a/lib/localization/de.dart
+++ b/lib/localization/de.dart
@@ -3,25 +3,25 @@ import 'package:duration_picker/localization/localization.dart';
 class DurationPickerLocalizationsDe extends DurationPickerLocalizations {
   @override
   String get baseUnitHour => 'Std.';
-  
+
   @override
   String get baseUnitMillisecond => 'ms';
-  
+
   @override
   String get baseUnitMinute => 'Min.';
-  
+
   @override
   String get baseUnitSecond => 'Sek.';
-  
+
   @override
   String get secondaryUnitHour => 'T ';
-  
+
   @override
   String get secondaryUnitMillisecond => 'S ';
-  
+
   @override
   String get secondaryUnitMinute => 'Std. ';
-  
+
   @override
   String get secondaryUnitSecond => 'Min. ';
 }

--- a/lib/localization/de.dart
+++ b/lib/localization/de.dart
@@ -1,0 +1,27 @@
+import 'package:duration_picker/localization/localization.dart';
+
+class DurationPickerLocalizationsDe extends DurationPickerLocalizations {
+  @override
+  String get baseUnitHour => 'Std.';
+  
+  @override
+  String get baseUnitMillisecond => 'ms';
+  
+  @override
+  String get baseUnitMinute => 'Min.';
+  
+  @override
+  String get baseUnitSecond => 'Sek.';
+  
+  @override
+  String get secondaryUnitHour => 'T ';
+  
+  @override
+  String get secondaryUnitMillisecond => 'S ';
+  
+  @override
+  String get secondaryUnitMinute => 'Std. ';
+  
+  @override
+  String get secondaryUnitSecond => 'Min. ';
+}

--- a/lib/localization/localization.dart
+++ b/lib/localization/localization.dart
@@ -1,5 +1,6 @@
 import 'package:duration_picker/localization/en.dart';
 import 'package:duration_picker/localization/ko.dart';
+import 'package:duration_picker/localization/de.dart';
 import 'package:flutter/material.dart';
 
 abstract class DurationPickerLocalizations {
@@ -35,7 +36,7 @@ class _DurationPickerLocalizationDelegate
     extends LocalizationsDelegate<DurationPickerLocalizations> {
   const _DurationPickerLocalizationDelegate();
 
-  static const supportedLocales = ['en', 'ko'];
+  static const supportedLocales = ['en', 'ko', 'de'];
 
   @override
   bool isSupported(Locale locale) =>
@@ -46,6 +47,8 @@ class _DurationPickerLocalizationDelegate
     switch (locale.languageCode) {
       case 'ko':
         return DurationPickerLocalizationsKo();
+      case 'de':
+        return DurationPickerLocalizationsDe();
       default:
         return DurationPickerLocalizationsEn();
     }


### PR DESCRIPTION
I really like your widget and use it a lot. But I am mainly developing apps for German and English speaking users. So I added the class for the German locale. If you like, you can merge it into your project. Let me know if something is missing.