### PR TITLE
Use OverflowBar with DatePickerTheme instead of the deprecated ButtonBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+* Replace deprecated ButtonBar by OverflowBar
+* Apply DatePickerTheme to the buttons
+
 ## 1.2.0
 * Add localization options
 * Update deprecated functions

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -722,6 +722,7 @@ class DurationPickerDialogState extends State<DurationPickerDialog> {
 
     final Widget actions = OverflowBar(
       spacing: 8,
+      alignment: MainAxisAlignment.end,
       children: <Widget>[
         TextButton(
           style: datePickerTheme.cancelButtonStyle ?? defaults.cancelButtonStyle,
@@ -747,7 +748,10 @@ class DurationPickerDialogState extends State<DurationPickerDialog> {
                 Expanded(
                   child: picker,
                 ), // picker grows and shrinks with the available space
-                actions,
+                Padding(
+                  padding: const EdgeInsets.all(2.0),
+                  child: actions,
+                ),
               ],
             ),
           );

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -701,9 +701,13 @@ class DurationPickerDialogState extends State<DurationPickerDialog> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
+    
     final theme = Theme.of(context);
+    final DatePickerThemeData datePickerTheme = DatePickerTheme.of(context);
+    final DatePickerThemeData defaults = DatePickerTheme.defaults(context);
     final boxDecoration =
         widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
+
     final Widget picker = Padding(
       padding: const EdgeInsets.all(16.0),
       child: AspectRatio(
@@ -716,20 +720,20 @@ class DurationPickerDialogState extends State<DurationPickerDialog> {
       ),
     );
 
-    final Widget actions = ButtonBarTheme(
-      data: ButtonBarTheme.of(context),
-      child: ButtonBar(
-        children: <Widget>[
-          TextButton(
-            onPressed: _handleCancel,
-            child: Text(localizations.cancelButtonLabel),
-          ),
-          TextButton(
-            onPressed: _handleOk,
-            child: Text(localizations.okButtonLabel),
-          ),
-        ],
-      ),
+    final Widget actions = OverflowBar(
+      spacing: 8,
+      children: <Widget>[
+        TextButton(
+          style: datePickerTheme.cancelButtonStyle ?? defaults.cancelButtonStyle,
+          onPressed: _handleCancel,
+          child: Text(localizations.cancelButtonLabel),
+        ),
+        TextButton(
+          style: datePickerTheme.confirmButtonStyle ?? defaults.confirmButtonStyle,
+          onPressed: _handleOk,
+          child: Text(localizations.okButtonLabel),
+        ),
+      ],
     );
 
     final dialog = Dialog(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: duration_picker
 description: A time picker widget that can select both minutes and hours. Fork from flutter_duration_picker.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/juliansteenbakker/duration_picker
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: duration_picker
 description: A time picker widget that can select both minutes and hours. Fork from flutter_duration_picker.
-version: 1.2.1
+version: 1.3.0
 homepage: https://github.com/juliansteenbakker/duration_picker
 
 environment:


### PR DESCRIPTION
- use OverflowBar instead of ButtonBar
- apply buttons theme from DatePickerTheme
- bump version to 1.3.0