### PR TITLE
Fix/should stop abrupt pan sign change allowance

### DIFF
--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -378,15 +378,47 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       final baseUnitSteps = _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
       final thetaPerBaseUnit = _kTwoPi / baseUnitSteps;
       final signChangeAllowance = thetaPerBaseUnit * 1.25; // tweak factor as needed
+      // 1.25 is a simple safety/hysteresis multiplier: it expands the dead-zone around the wrap boundary to 125% of
+      // one base-unit step so small/frequent pans or floating-point noise don't trigger an unwanted wrap-around.
+
+      // helper: shortest signed angular difference a - b in [-pi, pi]
+      double _shortestDiff(double a, double b) {
+        var diff = (a - b) % _kTwoPi;
+        if (diff > math.pi) diff -= _kTwoPi;
+        return diff;
+      }
+
+      // Compute dial angle and fractional base-unit value for the pointer position.
+      final dialAngle = (_kPiByTwo - angle) % _kTwoPi;
+      final pointerBaseUnitValue = dialAngle / _kTwoPi * baseUnitSteps;
+
+      // If pointer is very close to zero (less than half a base-unit) and we're at zero secondary units,
+      // snap to exact zero to avoid residual 1-second (or 1-minute) values.
+      const double snapThreshold = 0.5; // half a base-unit
+      if (pointerBaseUnitValue <= snapThreshold && _secondaryUnitValue == 0) {
+        // Force dial to exact top and ensure turning angle maps to zero duration.
+        _thetaTween
+          ..begin = _kCircleTop
+          ..end = _kCircleTop;
+
+        // Ensure internal turning angle maps to zero duration (safety for immediate reads).
+        _turningAngle = _kPiByTwo;
+        return;
+      }
 
       // Stop accidental abrupt pans from making the dial seem like it starts from 1h.
       // (happens when wanting to pan from 0 clockwise, but when doing so quickly, one actually pans from before 0 ...)
+      // absolute angular distance from current dial position to the top (wrap boundary)
+      final currentToTop = _shortestDiff(_theta.value, _kCircleTop).abs();
+
+      // detect a crossing of the top but only block it when the current dial
+      // is within the allowance around the top and we are at zero secondary units.
       final shouldStopAbruptPan = angle >= _kCircleTop &&
           _theta.value <= _kCircleTop &&
-          _theta.value >= signChangeAllowance &&
+          currentToTop <= signChangeAllowance &&
           _secondaryUnitValue == 0;
 
-      print(' angle: $angle, _theta.value: ${_theta.value}, shouldStopAbruptPan: $shouldStopAbruptPan');
+      // print(' angle: $angle, _theta.value: ${_theta.value}, shouldStopAbruptPan: $shouldStopAbruptPan');
 
       if (shouldStopAbruptPan) return;
 
@@ -478,8 +510,11 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     // Coordinate transformation from mathematical COS to dial COS
     final dialAngle = _kPiByTwo - angle;
 
-    // Turn dial angle into minutes, may go beyond 60 minutes (multiple turns)
-    return dialAngle / _kTwoPi * _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
+    // Turn dial angle into base units (may go beyond one secondary unit for multiple turns)
+    final value = dialAngle / _kTwoPi * _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
+
+    // Prevent negative base-unit values which lead to negative Duration when dragging fast past 0.
+    return value < 0.0 ? 0.0 : value;
   }
 
   void _updateTurningAngle(double oldTheta, double newTheta) {
@@ -505,6 +540,13 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       _turningAngle = _upperBoundAngle!;
     } else if (_lowerBoundAngel != null && _turningAngle > _lowerBoundAngel!) {
       _turningAngle = _lowerBoundAngel!;
+    }
+
+    // Additional safety: the mapping to Duration expects dialAngle >= 0.
+    // That corresponds to _turningAngle <= _kPiByTwo. Clamp to avoid negative Durations
+    // when the user drags very fast past the zero boundary.
+    if (_turningAngle > _kPiByTwo) {
+      _turningAngle = _kPiByTwo;
     }
   }
 

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -76,7 +76,8 @@ class DialPainter extends CustomPainter {
 
     // Get the offset point for an angle value of theta, and a distance of _radius
     Offset getOffsetForTheta(double theta, double radius) {
-      return center + Offset(radius * math.cos(theta), -radius * math.sin(theta));
+      return center +
+          Offset(radius * math.cos(theta), -radius * math.sin(theta));
     }
 
     // Draw the handle that is used to drag and to indicate the position around the circle
@@ -117,14 +118,19 @@ class DialPainter extends CustomPainter {
     }
 
     // Draw the Text in the center of the circle which displays the duration string
-    final secondaryUnits = (baseUnitMultiplier == 0) ? '' : '$baseUnitMultiplier${getSecondaryUnitString()} ';
+    final secondaryUnits = (baseUnitMultiplier == 0)
+        ? ''
+        : '$baseUnitMultiplier${getSecondaryUnitString()} ';
     final baseUnits = '$baseUnitHand';
 
     final textDurationValuePainter = TextPainter(
       textAlign: TextAlign.center,
       text: TextSpan(
         text: '$secondaryUnits$baseUnits',
-        style: Theme.of(context).textTheme.displayMedium!.copyWith(fontSize: size.shortestSide * 0.15),
+        style: Theme.of(context)
+            .textTheme
+            .displayMedium!
+            .copyWith(fontSize: size.shortestSide * 0.15),
       ),
       textDirection: TextDirection.ltr,
     )..layout();
@@ -146,7 +152,9 @@ class DialPainter extends CustomPainter {
       canvas,
       Offset(
         centerPoint.dx - (textMinPainter.width / 2),
-        centerPoint.dy + (textDurationValuePainter.height / 2) - textMinPainter.height / 2,
+        centerPoint.dy +
+            (textDurationValuePainter.height / 2) -
+            textMinPainter.height / 2,
       ),
     );
 
@@ -247,8 +255,12 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     _secondaryUnitValue = _secondaryUnitHand();
     _baseUnitValue = _baseUnitHand();
 
-    _upperBoundAngle = widget.upperBound != null ? _kPiByTwo - _turningAngleFactor(widget.upperBound) * _kTwoPi : null;
-    _lowerBoundAngel = widget.lowerBound != null ? _kPiByTwo - _turningAngleFactor(widget.lowerBound) * _kTwoPi : null;
+    _upperBoundAngle = widget.upperBound != null
+        ? _kPiByTwo - _turningAngleFactor(widget.upperBound) * _kTwoPi
+        : null;
+    _lowerBoundAngel = widget.lowerBound != null
+        ? _kPiByTwo - _turningAngleFactor(widget.lowerBound) * _kTwoPi
+        : null;
   }
 
   late ThemeData themeData;
@@ -285,7 +297,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   void _animateTo(double targetTheta) {
     final currentTheta = _theta.value;
-    var beginTheta = _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
+    var beginTheta =
+        _nearest(targetTheta, currentTheta, currentTheta + _kTwoPi);
     beginTheta = _nearest(targetTheta, beginTheta, currentTheta - _kTwoPi);
     _thetaTween
       ..begin = beginTheta
@@ -342,9 +355,14 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   double _getThetaForDuration(Duration duration, BaseUnit baseUnit) {
     final int baseUnits = _getDurationInBaseUnits(duration, baseUnit);
-    final int baseToSecondaryFactor = _getBaseUnitToSecondaryUnitFactor(baseUnit);
+    final int baseToSecondaryFactor =
+        _getBaseUnitToSecondaryUnitFactor(baseUnit);
 
-    return (_kPiByTwo - (baseUnits % baseToSecondaryFactor) / baseToSecondaryFactor.toDouble() * _kTwoPi) % _kTwoPi;
+    return (_kPiByTwo -
+            (baseUnits % baseToSecondaryFactor) /
+                baseToSecondaryFactor.toDouble() *
+                _kTwoPi) %
+        _kTwoPi;
   }
 
   double _turningAngleFactor(Duration? duration) {
@@ -377,7 +395,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       // This avoids a magic `0.1` that misclassifies ~14min as the 15min wrap.
       final baseUnitSteps = _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
       final thetaPerBaseUnit = _kTwoPi / baseUnitSteps;
-      final signChangeAllowance = thetaPerBaseUnit * 1.25; // tweak factor as needed
+      final signChangeAllowance =
+          thetaPerBaseUnit * 1.25; // tweak factor as needed
       // 1.25 is a simple safety/hysteresis multiplier: it expands the dead-zone around the wrap boundary to 125% of
       // one base-unit step so small/frequent pans or floating-point noise don't trigger an unwanted wrap-around.
 
@@ -511,7 +530,9 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     final dialAngle = _kPiByTwo - angle;
 
     // Turn dial angle into base units (may go beyond one secondary unit for multiple turns)
-    final value = dialAngle / _kTwoPi * _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
+    final value = dialAngle /
+        _kTwoPi *
+        _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
 
     // Prevent negative base-unit values which lead to negative Duration when dragging fast past 0.
     return value < 0.0 ? 0.0 : value;
@@ -610,7 +631,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
         const int interval = 3;
         const int factor = Duration.hoursPerDay;
         const int length = factor ~/ interval;
-        baseUnitMarkerValues = List.generate(length, (index) => Duration(hours: index * interval));
+        baseUnitMarkerValues =
+            List.generate(length, (index) => Duration(hours: index * interval));
         break;
     }
 
@@ -733,7 +755,8 @@ class DurationPickerDialogState extends State<DurationPickerDialog> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     final theme = Theme.of(context);
-    final boxDecoration = widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
+    final boxDecoration =
+        widget.decoration ?? BoxDecoration(color: theme.dialogBackgroundColor);
     final Widget picker = Padding(
       padding: const EdgeInsets.all(16.0),
       child: AspectRatio(

--- a/lib/duration_picker.dart
+++ b/lib/duration_picker.dart
@@ -375,7 +375,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
       // Adaptive threshold: one step (or slightly more) of the current base unit in radians.
       // This avoids a magic `0.1` that misclassifies ~14min as the 15min wrap.
-      final baseUnitSteps = widget.baseUnitDenomination.getBaseUnitToSecondaryUnitFactor();
+      final baseUnitSteps = _getBaseUnitToSecondaryUnitFactor(widget.baseUnit);
       final thetaPerBaseUnit = _kTwoPi / baseUnitSteps;
       final signChangeAllowance = thetaPerBaseUnit * 1.25; // tweak factor as needed
 


### PR DESCRIPTION
When the duration picker is at 14 minutes, the bottom half of the thumb wheel does not respond. This is due to the calculation for shouldStopAbruptPan misfiring.

This code fixes that, along with some clamping to avoid going into negative numbers and some stickiness around trying to drag to zero but it getting stuck at 1 or 2.

This was fixed with copilot, i dont understand the math but it works....here is its explanation of the  fix:

"The hard-coded 0.1 is too small and not tied to the selected base unit. Replace it with an adaptive threshold based on the angular step per base unit so the "allow sign change at 15 mins" behavior scales correctly (and won't fire at 14 mins). Below is a minimal change to _updateThetaForPan."

and for the signChangeAllowance

"The 1.25 is a simple safety/hysteresis multiplier: it expands the dead-zone around the wrap boundary to 125% of one base-unit step so small/frequent pans or floating-point noise don't trigger an unwanted wrap-around.
How it's computed:

thetaPerBaseUnit = 2π / baseUnitSteps (e.g. for minutes baseUnitSteps = 60 → thetaPerBaseUnit ≈ 0.10472 rad).
signChangeAllowance = thetaPerBaseUnit * 1.25 → for minutes ≈ 0.1309 rad (≈ 7.5° ≈ 1.25 minute on the dial).

How it affects the shouldStopAbruptPan check:
The check requires _theta.value >= signChangeAllowance to consider the current dial position “far enough” from zero that a quick pan across the top should be ignored.
Increasing the multiplier makes the dead-zone bigger (harder to wrap) — reduces false wraps but can also block legitimate small moves near zero.

Decreasing it makes the dead-zone smaller (easier to wrap) — more sensitive to small pans.

Numeric intuition:
Minutes: one step = ~0.1047 rad; *1.25 → ~0.1309 rad (adds ~25% margin).
Seconds (60 steps) same numbers. Hours (24 steps): thetaPerBaseUnit = 2π/24 ≈ 0.2618 rad; *1.25 ≈ 0.3273 rad.

Tuning suggestions (choose one):
Keep 1.25 if you want a mild margin.
Use 1.0 for exact one-step margin.
Use >1.25 (e.g. 1.5) to be more conservative.
Or compute dynamically from drag velocity or use a boolean hysteresis that compares angular delta magnitudes instead of a fixed multiplier.
